### PR TITLE
ensure the pool_size option is an integer

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -28,4 +28,4 @@ config :cellect, Cellect.Repo,
   password: System.get_env("POSTGRES_PASS") || "",
   database: System.get_env("POSTGRES_DB")   || "cellect_ex_development",
   hostname: System.get_env("POSTGRES_HOST") || "localhost",
-  pool_size: System.get_env("POSTGRES_POOL_SIZE") || 10
+  pool_size: String.to_integer(System.get_env("POSTGRES_POOL_SIZE")|| "10")

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -31,7 +31,7 @@ config :cellect, Cellect.Repo,
   password: System.get_env("POSTGRES_PASS"),
   database: System.get_env("POSTGRES_DB"),
   hostname: System.get_env("POSTGRES_HOST"),
-  pool_size: System.get_env("POSTGRES_POOL_SIZE"),
+  pool_size: String.to_integer(System.get_env("POSTGRES_POOL_SIZE") || "5"),
   ssl: true
 
 # ## SSL Support


### PR DESCRIPTION
~~Couldn't test locally as the docker containers built but wouldn't start. Happy to do something else if i can get this tested instead of testing via staging deploy.~~

Tested on the running container and this works, seems the default fallback is 5 somehow if the string is passed, 10 if null...weird.